### PR TITLE
use Require for depending on Paramcoq, update requirements and CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,15 +17,16 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'mathcomp/mathcomp:1.12.0-coq-8.14'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
           - 'mathcomp/mathcomp:1.12.0-coq-8.12'
           - 'mathcomp/mathcomp:1.12.0-coq-8.11'
           - 'mathcomp/mathcomp:1.12.0-coq-8.10'
           - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp-dev:coq-8.14'
           - 'mathcomp/mathcomp-dev:coq-8.13'
           - 'mathcomp/mathcomp-dev:coq-8.12'
           - 'mathcomp/mathcomp-dev:coq-8.11'
-          - 'mathcomp/mathcomp-dev:coq-8.10'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ of the ForMath EU FP7 project (2009-2013). It has two parts:
 - Compatible Coq versions: 8.10 or later (use releases for other Coq versions)
 - Additional dependencies:
   - [Bignums](https://github.com/coq/bignums) same version as Coq
-  - [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.1 or later
+  - [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.3 or later
   - [MathComp Multinomials](https://github.com/math-comp/multinomials) >= 1.5.1 and < 1.7
   - [MathComp](https://math-comp.github.io) 1.12.0 or newer
 - Coq namespace: `CoqEAL`

--- a/coq-coqeal.opam
+++ b/coq-coqeal.opam
@@ -17,12 +17,12 @@ of the ForMath EU FP7 project (2009-2013). It has two parts:
 - theory, which contains developments in algebra and optimized algorithms on mathcomp data structures.
 - refinements, which is a framework to ease change of data representations during a proof."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.15~") | (= "dev")}
   "coq-bignums" 
-  "coq-paramcoq" {>= "1.1.1"}
+  "coq-paramcoq" {>= "1.1.3"}
   "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
   "coq-mathcomp-algebra" {((>= "1.12.0" & < "1.14~") | = "dev")}
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -66,7 +66,7 @@ license:
 
 supported_coq_versions:
   text: 8.10 or later (use releases for other Coq versions)
-  opam: '{(>= "8.10" & < "8.14~") | (= "dev")}'
+  opam: '{(>= "8.10" & < "8.15~") | (= "dev")}'
 
 dependencies:
 - opam:
@@ -75,9 +75,9 @@ dependencies:
     [Bignums](https://github.com/coq/bignums) same version as Coq
 - opam:
     name: coq-paramcoq
-    version: '{>= "1.1.1"}'
+    version: '{>= "1.1.3"}'
   description: |-
-    [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.1 or later
+    [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.3 or later
 - opam:
     name: coq-mathcomp-multinomials
     version: '{((>= "1.5.1" & < "1.7~") | = "dev")}'
@@ -90,6 +90,8 @@ dependencies:
     [MathComp](https://math-comp.github.io) 1.12.0 or newer
 
 tested_coq_opam_versions:
+- version: '1.12.0-coq-8.14'
+  repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.12'
@@ -100,13 +102,13 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
+- version: 'coq-8.14'
+  repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.13'
   repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.12'
   repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.11'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.10'
   repo: 'mathcomp/mathcomp-dev'
 
 namespace: CoqEAL

--- a/refinements/param.v
+++ b/refinements/param.v
@@ -1,10 +1,9 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq fintype.
+From Param Require Import Param.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-
-Declare ML Module "paramcoq".
 
 Global Ltac destruct_reflexivity :=
   intros ; repeat match goal with


### PR DESCRIPTION
Since Coq 8.14 is out, and Paramcoq 1.1.3 is out that supports using `Require` to depend on it, here is a PR that updates to support this.

Note that the only reason we drop compatibility with Coq 8.10 to 8.12 is that there currently no Paramcoq 1.1.3 for those Coq versions. Should we do Paramcoq 1.1.3 releases for them maybe?